### PR TITLE
Dockerized the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM ubuntu:xenial
 MAINTAINER Tammer Barkouki (thbarkouki@ucdavis.edu)
 
 RUN apt-get update && apt-get upgrade -y \
-&& apt-get install -y build-essential git \
-&& apt-get install -y sudo wget nano \
+&& apt-get install -y build-essential git sudo wget nano \
 && mkdir $HOME/myfreeflyer \
 && export SOURCE_PATH=$HOME/myfreeflyer \
 && git clone https://github.com/nasa/astrobee.git $SOURCE_PATH \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,5 @@ RUN apt-get update && apt-get upgrade -y \
 && export INSTALL_PATH=$HOME/freeflyer_install/native \
 && ./scripts/configure.sh -l -F -D \
 && cd $BUILD_PATH \
-&& make -j2 \
+&& make -j8 \
 && cd $SOURCE_PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,19 @@ FROM ubuntu:xenial
 MAINTAINER Tammer Barkouki (thbarkouki@ucdavis.edu)
 
 RUN apt-get update && apt-get upgrade -y \
-&& apt-get install -y build-essential git sudo wget nano \
-&& mkdir $HOME/myfreeflyer \
-&& export SOURCE_PATH=$HOME/myfreeflyer \
-&& git clone https://github.com/nasa/astrobee.git $SOURCE_PATH \
-&& cd $SOURCE_PATH/scripts/setup \
-&& ./add_ros_repository.sh \
+&& apt-get install -y build-essential git sudo wget nano
+
+RUN mkdir $HOME/myfreeflyer
+
+WORKDIR $HOME/myfreeflyer
+
+ENV SOURCE_PATH $HOME/myfreeflyer \
+
+# Get Astrobee
+RUN git clone https://github.com/nasa/astrobee.git \
+&& ./scripts/setup/add_ros_repository.sh
+
+# get ROS
 && sed -i 's/main/xenial main/g' /etc/apt/sources.list.d/gazebo-stable.list \
 && sed -i 's/main/xenial main/g' /etc/apt/sources.list.d/ros-latest.list \
 && apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,7 @@ WORKDIR $HOME/myfreeflyer
 ENV SOURCE_PATH $HOME/myfreeflyer \
 
 # Get Astrobee
-RUN git clone https://github.com/nasa/astrobee.git \
-&& ./scripts/setup/add_ros_repository.sh
+RUN git clone https://github.com/nasa/astrobee.git
 
 # get ROS
 && sed -i 's/main/xenial main/g' /etc/apt/sources.list.d/gazebo-stable.list \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,15 @@ RUN git clone https://github.com/nasa/astrobee.git
 RUN ./scripts/setup/add_ros_repository.sh \
 && sed -i 's/main/xenial main/g' /etc/apt/sources.list.d/gazebo-stable.list \
 && sed -i 's/main/xenial main/g' /etc/apt/sources.list.d/ros-latest.list \
-&& apt-get update \
-&& cd debians \
-&& ./build_install_debians.sh \
-&& cd ../ \
-&& ./install_desktop_16_04_packages.sh \
-&& sudo rosdep init \
+# do we need an upgrade after update? is that in a script?
+&& apt-get update 
+
+# Not yet sure what these do (see just above)
+RUN ./debians/build_install_debians.sh \
+&& ./install_desktop_16_04_packages.sh
+
+# Update ROS
+RUN sudo rosdep init \
 && rosdep update \
 && cd $SOURCE_PATH \
 && export BUILD_PATH=$HOME/freeflyer_build/native \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get upgrade -y \
 
 # Put this on a seperate line so we can install things we miss without having to re-do everything
 RUN apt-get update \
-&& apt-get install -y build-essential git sudo wget nano lsb_release
+&& apt-get install -y build-essential git sudo wget nano lsb-release
 
 WORKDIR $HOME/myfreeflyer
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,21 +8,21 @@ RUN apt-get update && apt-get upgrade -y
 RUN apt-get update \
 && apt-get install -y build-essential git sudo wget nano lsb-release
 
-WORKDIR $HOME/myfreeflyer
-
 # Get Astrobee
 RUN git clone https://github.com/nasa/astrobee.git
+
+WORKDIR $HOME/astrobee
 
 # update apt lists and install ROS
 RUN ./scripts/setup/add_ros_repository.sh
 
-# Not yet sure what these do (see just above), you have to be in the directory to run this script because a variable assings `pwd`...disgusting
-RUN cd scripts/setup/debians \
+# You have to be in the directory to run this script because a variable assigns `pwd`...disgusting
+RUN apt-get update \
+&& cd scripts/setup/debians \
 && ./build_install_debians.sh
 
-# Not yet sure what these do (see just above)
-RUN ./debians/build_install_debians.sh \
-&& ./install_desktop_16_04_packages.sh
+RUN apt-get update \
+&& ./scripts/setup/install_desktop_16_04_packages.sh
 
 # Update ROS, get ready for build
 RUN sudo rosdep init \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,3 +32,5 @@ RUN sudo rosdep init \
 # Finally build!
 RUN cd $HOME/freeflyer_build/native \
 && make -j$((`nproc`+1))
+
+RUN echo "source /root/freeflyer_build/native/devel/setup.bash" >> /root/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM ubuntu:xenial
 MAINTAINER Tammer Barkouki (thbarkouki@ucdavis.edu)
 
-#apt-get upgrade isn't great practice in a dockerfile because it's bloating, but we'll keep it for now.
+# apt-get upgrade isn't great practice in a dockerfile because it's bloating, but we'll keep it for now.
 RUN apt-get update && apt-get upgrade -y \
-&& apt-get install -y build-essential git sudo wget nano
 
-RUN mkdir $HOME/myfreeflyer
+# Put this on a seperate line so we can install things we miss without having to re-do everything
+RUN apt-get update \
+&& apt-get install -y build-essential git sudo wget nano lsb_release
 
 WORKDIR $HOME/myfreeflyer
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ ENV SOURCE_PATH $HOME/myfreeflyer \
 # Get Astrobee
 RUN git clone https://github.com/nasa/astrobee.git
 
-# get ROS
+# update apt lists and install ROS
+RUN ./scripts/setup/add_ros_repository.sh \
 && sed -i 's/main/xenial main/g' /etc/apt/sources.list.d/gazebo-stable.list \
 && sed -i 's/main/xenial main/g' /etc/apt/sources.list.d/ros-latest.list \
 && apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:xenial
 MAINTAINER Tammer Barkouki (thbarkouki@ucdavis.edu)
 
 # apt-get upgrade isn't great practice in a dockerfile because it's bloating, but we'll keep it for now.
-RUN apt-get update && apt-get upgrade -y \
+RUN apt-get update && apt-get upgrade -y
 
 # Put this on a seperate line so we can install things we miss without having to re-do everything
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,7 @@ RUN ./debians/build_install_debians.sh \
 # Update ROS
 RUN sudo rosdep init \
 && rosdep update \
-&& cd $SOURCE_PATH \
-&& export BUILD_PATH=$HOME/freeflyer_build/native \
-&& export INSTALL_PATH=$HOME/freeflyer_install/native \
-&& ./scripts/configure.sh -l -F -D \
-&& cd $BUILD_PATH \
-&& make -j8 \
-&& cd $SOURCE_PATH
+&& ./scripts/configure.sh -l -F -D
+
+RUN cd $HOME/freeflyer_build/native \
+&& make -j8

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,11 @@ WORKDIR $HOME/myfreeflyer
 RUN git clone https://github.com/nasa/astrobee.git
 
 # update apt lists and install ROS
-RUN ./scripts/setup/add_ros_repository.sh \
-&& sed -i 's/main/xenial main/g' /etc/apt/sources.list.d/gazebo-stable.list \
-&& sed -i 's/main/xenial main/g' /etc/apt/sources.list.d/ros-latest.list \
-# do we need an upgrade after update? is that in a script?
-&& apt-get update 
+RUN ./scripts/setup/add_ros_repository.sh
+
+# Not yet sure what these do (see just above), you have to be in the directory to run this script because a variable assings `pwd`...disgusting
+RUN cd scripts/setup/debians \
+&& ./build_install_debians.sh
 
 # Not yet sure what these do (see just above)
 RUN ./debians/build_install_debians.sh \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 FROM ubuntu:xenial
 MAINTAINER Tammer Barkouki (thbarkouki@ucdavis.edu)
 
+#apt-get upgrade isn't great practice in a dockerfile because it's bloating, but we'll keep it for now.
 RUN apt-get update && apt-get upgrade -y \
 && apt-get install -y build-essential git sudo wget nano
 
 RUN mkdir $HOME/myfreeflyer
 
 WORKDIR $HOME/myfreeflyer
-
-ENV SOURCE_PATH $HOME/myfreeflyer \
 
 # Get Astrobee
 RUN git clone https://github.com/nasa/astrobee.git
@@ -24,10 +23,11 @@ RUN ./scripts/setup/add_ros_repository.sh \
 RUN ./debians/build_install_debians.sh \
 && ./install_desktop_16_04_packages.sh
 
-# Update ROS
+# Update ROS, get ready for build
 RUN sudo rosdep init \
 && rosdep update \
 && ./scripts/configure.sh -l -F -D
 
+# Finally build!
 RUN cd $HOME/freeflyer_build/native \
-&& make -j8
+&& make -j$((`nproc`+1))

--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
+docker container stop $(docker container ls -aq)
+
 docker-compose up -d
-docker exec -d astrobee_sim_container /bin/bash -c "source /root/freeflyer_build/native/devel/setup.bash \
-&& roslaunch astrobee sim.launch dds:=false robot:=sim_pub rviz:=true"
+docker exec -d astrobee_sim_container /bin/bash -c "roslaunch astrobee sim.launch dds:=false robot:=sim_pub rviz:=true"
 echo "Opening browser interface..."
 sleep 1
 xdg-open http://localhost:8080/vnc_auto.html &

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,8 @@
 docker container stop $(docker container ls -aq)
 
 docker-compose up -d
-docker exec -d astrobee_sim_container /bin/bash -c "roslaunch astrobee sim.launch dds:=false robot:=sim_pub rviz:=true"
+docker exec -d astrobee_sim_container /bin/bash -c "source /root/freeflyer_build/native/devel/setup.bash \
+&& roslaunch astrobee sim.launch dds:=false robot:=sim_pub rviz:=true"
 echo "Opening browser interface..."
 sleep 1
 xdg-open http://localhost:8080/vnc_auto.html &

--- a/run.sh
+++ b/run.sh
@@ -3,3 +3,6 @@
 docker-compose up -d
 docker exec -d astrobee_sim_container /bin/bash -c "source /root/freeflyer_build/native/devel/setup.bash \
 && roslaunch astrobee sim.launch dds:=false robot:=sim_pub rviz:=true"
+echo "Opening browser interface..."
+sleep 1
+xdg-open http://localhost:8080/vnc_auto.html &


### PR DESCRIPTION
Docker has an easier time when these commands are split up because the successful commands are cached for the next time you build. This means if something fails halfway through, you don't have to rebuild the entire thing.
Some other changes:
- make -j flag to speed up the final build. too bad the intermediate scripts don't allow this.
- extraneous environment variables
- auto browser in the run script

Last time I built took an hour :-1: 